### PR TITLE
API-4759

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ tmp
 yarn-debug.log
 yarn-error.log
 .bloop
+/api-repos/

--- a/src/main/scala/repos/RepoFileExport.scala
+++ b/src/main/scala/repos/RepoFileExport.scala
@@ -53,7 +53,7 @@ object RepoFileExport {
     Try({
       val model : WebApiDocument = Raml10.parse(filename).get().asInstanceOf[WebApiDocument]
 
-      val outputFilepath = s"file://generated/${csvApiRecord.name}-${csvApiRecord.version}.yaml"
+      val outputFilepath = s"file://generated/${csvApiRecord.name}.yaml"
 
       addAccessTypeToDescription(model, csvApiRecord)
 


### PR DESCRIPTION
Remove version from API Platform filename
As it it used as publisher reference, which doesn't need the version number